### PR TITLE
The target directory won't exist until the 'cowbuilder' package is insta...

### DIFF
--- a/manifests/setup/cows.pp
+++ b/manifests/setup/cows.pp
@@ -101,6 +101,7 @@ class debbuilder::setup::cows (
   debbuilder::util::file_on_disk { ["oneiric", "precise", "quantal", "wheezy"]:
     source    => "puppet:///modules/debbuilder/",
     target    => "/usr/share/debootstrap/scripts/",
+    require   => Package["cowbuilder"],
   }
 
   # If $pe is true, lay down the pluto-build-keyring to correctly


### PR DESCRIPTION
...lled, so this adds it as a requirement.
