### PR TITLE
Test if FOSS_DEVEL is a specific string, not just that it exists

### DIFF
--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -54,7 +54,7 @@ APTCACHE="/var/cache/pbuilder/${NAME}/aptcache/"
 BUILDPLACE="/var/cache/pbuilder/build/"
 #BINDMOUNTS="/var/cache/archive"
 
-if [ -n "${FOSS_DEVEL}" ] ; then
+if [ "${FOSS_DEVEL}" = 'true' ] ; then
   OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} main dependencies devel"
 else
   OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} main dependencies"


### PR DESCRIPTION
A bit more specificity here allows us saner packaging repo use.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
