### PR TITLE
Add bundler to extra packages in debbuilder module

### DIFF
--- a/manifests/packages/extra.pp
+++ b/manifests/packages/extra.pp
@@ -11,6 +11,7 @@ class debbuilder::packages::extra {
     'debian-archive-keyring',
     'debian-keyring',
     'pbuilder',
+    'ruby-bundler',
   ]
 
   package { $extra_packages: ensure => present, }


### PR DESCRIPTION
We're going to start using bundler in dashboard packaging, which means we need
it to be present on the builders.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
