### PR TITLE
maint/cowsay in debbuilder

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,9 @@ class debbuilder (
   include debbuilder::packages::essential
 
   if ($use_cows) {
-    include debbuilder::packages::extra
+    class { 'debbuilder::packages::extra':
+      pe => $pe,
+    }
 
     class { 'debbuilder::setup::cows':
       cows => $cows,

--- a/manifests/packages/extra.pp
+++ b/manifests/packages/extra.pp
@@ -3,7 +3,10 @@
 # helpful when dealing with cowbuilder on the command line.  The debian keyring
 # packages are needed for bootstrapping the cows during setup.
 
-class debbuilder::packages::extra {
+class debbuilder::packages::extra (
+  $pe = false
+){
+
   $extra_packages = [
     'bash-completion',
     'cowbuilder',
@@ -16,4 +19,10 @@ class debbuilder::packages::extra {
   ]
 
   package { $extra_packages: ensure => present, }
+
+  if ($pe) {
+    package { 'cowsay':
+      ensure => present,
+    }
+  }
 }


### PR DESCRIPTION
This commit modified the puppetlabs-debbuilder so that it includes
cowsay if we're provisioning a deb platform to build a pe package.
