### PR TITLE
Remove Oneiric from debbuilder

### DIFF
--- a/manifests/setup/cows.pp
+++ b/manifests/setup/cows.pp
@@ -14,7 +14,6 @@
 class debbuilder::setup::cows (
   $cows = [
     'lucid',
-    'oneiric',
     'precise',
     'quantal',
     'raring',

--- a/spec/classes/setup_cows_spec.rb
+++ b/spec/classes/setup_cows_spec.rb
@@ -20,7 +20,7 @@ describe 'debbuilder::setup::cows', :type => :class do
   ].each do |param_set|
     context "when #{param_set == {} ? "using default" : "specifying"} class parameters" do
       default_params =
-      { :cows     => [ "lucid", "squeeze", "oneiric", "precise", "quantal", "sid", "stable", "testing", "unstable", "wheezy" ],
+      { :cows     => [ "lucid", "squeeze", "precise", "quantal", "sid", "stable", "testing", "unstable", "wheezy" ],
         :cow_root => "/var/cache/pbuilder",
         :pe       => false,
       }


### PR DESCRIPTION
Because Oneiric went end of life in May, we don't want to keep it around
as a cow.
