### PR TITLE
Update pbuilderrc for new PE repos

### DIFF
--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -70,7 +70,7 @@ APTKEYRINGS="/usr/share/keyrings/puppetlabs-keyring.gpg"
 
 <% if scope.lookupvar("debbuilder::setup::cows::pe") then %>
 if [ -n "${PE_VER}" ]; then
-  OTHERMIRROR="${OTHERMIRROR} | deb http://freight.puppetlabs.lan ${PE_VER} ${DIST}"
+  OTHERMIRROR="${OTHERMIRROR} | deb http://enterprise.delivery.puppetlabs.net/${PE_VER}/repos/debian ${DIST} main"
 
   # Add pluto
   DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/pluto-build-keyring.gpg")


### PR DESCRIPTION
We're changing the location of our PE repos, so we need to update pbuilderrc
for dependencies.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
