### PR TITLE
(maint) Attempt to prevent invalid cross link device errors

### DIFF
--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -55,6 +55,7 @@ BASEPATH="<%= scope.lookupvar("debbuilder::setup::cows::cow_root") %>/base-${NAM
 DISTRIBUTION="$DIST"
 BUILDRESULT="/var/cache/pbuilder/${NAME}/result/"
 APTCACHE="/var/cache/pbuilder/${NAME}/aptcache/"
+APTCACHEHARDLINK=no
 BUILDPLACE="/var/cache/pbuilder/build/"
 #BINDMOUNTS="/var/cache/archive"
 


### PR DESCRIPTION
When adding new cows and provisioning new builders, it is common to have a cow
build fail when trying to link/mount proc elements. The pbuilder documentation
suggests adding the APTCACHEHARDLINK=no declaration to pbuilderrc to help
minimize this possibility. I have no idea if this will actually help.

http://www.netfort.gr.jp/~dancer/software/pbuilder-doc/pbuilder-doc.html#lninvalidcrossdevicelink
