### PR TITLE
Update debbuilder module to support power, arm

### DIFF
--- a/manifests/setup/cow_exec.pp
+++ b/manifests/setup/cow_exec.pp
@@ -26,23 +26,43 @@ define debbuilder::setup::cow_exec ( $cow_root = '/var/cache/pbuilder' ) {
     }
   }
 
-  if ($::architecture == 'amd64') {
-    exec { "${name}-amd64":
+  if ($::architecture =~ /(?i)(amd64|arm(el|hf)?)/) {
+    exec { "${name}-${::architecture}":
       path          => '/usr/sbin:/usr/bin:/bin:/sbin',
-      command       => "cowbuilder --create --basepath=${cow_root}/base-${name}-amd64.cow/ --debug",
-      unless        => "test -e ${cow_root}/base-${name}-amd64.cow",
-      environment   => ["DIST=${name}", 'ARCH=amd64'],
+      command       => "cowbuilder --create --basepath=${cow_root}/base-${name}-${::architecture}/ --debug",
+      unless        => "test -e ${cow_root}/base-${name}-${::architecture}.cow",
+      environment   => ["DIST=${name}", "ARCH=${::architecture}"],
       logoutput     => on_failure,
       user          => root,
       timeout       => 0,
     }
 
-    cron { "${name}-amd64":
-      command       => "cowbuilder --update --basepath=${cow_root}/base-${name}-amd64.cow > /dev/null 2>&1",
-      environment   => ["DIST=${name}", 'ARCH=amd64', 'PATH=/usr/sbin:/usr/bin:/bin:/sbin'],
+    cron { "${name}-${::architecture}":
+      command       => "cowbuilder --update --basepath=${cow_root}/base-${name}-${::architecture}.cow > /dev/null 2>&1",
+      environment   => ["DIST=${name}", "ARCH=${::architecture}", 'PATH=/usr/sbin:/usr/bin:/bin:/sbin'],
       hour          => '2',
       minute        => '15',
-      name          => "cowbuilder update for ${name}-amd64",
+      name          => "cowbuilder update for ${name}-${::architecture}",
+      user          => root,
+    }
+  }
+
+  if ($::architecture =~ /(?i)(powerpc|ppc(64|32)?)$/) {
+    exec { "${name}-powerpc":
+      command       => "cowbuilder --create --basepath=${cow_root}/base-${name}-powerpc.cow/ --debug",
+      unless        => "test -e ${cow_root}/base-${name}-powerpc.cow",
+      environment   => ["DIST=${name}", "ARCH=powerpc"],
+      logoutput     => on_failure,
+      user          => root,
+      timeout       => 0,
+    }
+
+    cron { "${name}-powerpc":
+      command       => "cowbuilder --update --basepath=${cow_root}/base-${name}-powerpc.cow > /dev/null 2>&1",
+      environment   => ["DIST=${name}", "ARCH=powerpc", 'PATH=/usr/sbin:/usr/bin:/bin:/sbin'],
+      hour          => '2',
+      minute        => '15',
+      name          => "cowbuilder update for ${name}-powerpc",
       user          => root,
     }
   }

--- a/spec/defines/setup_cow_exec_spec.rb
+++ b/spec/defines/setup_cow_exec_spec.rb
@@ -19,13 +19,35 @@ describe 'debbuilder::setup::cow_exec', :type => :define do
       let :params do
         param_set
       end
-      arches = ['i386', 'amd64']
+      arches = ['i386', 'amd64', 'ppc', 'powerpc', 'ppc32', 'ppc64', 'arm']
 
       arches.each do | arch_fact |
         context "on #{arch_fact}" do
           let(:facts) do { :architecture => arch_fact } end
           arches.each do | arch |
-            if (arch_fact == "amd64") or (arch_fact == arch)
+            if (arch_fact =~ /(amd64|i386)/)
+              it do should contain_exec("#{title}-i386").with( {
+                  :path         => "/usr/sbin:/usr/bin:/bin:/sbin",
+                  :command      => "cowbuilder --create --basepath=#{param_hash[:cow_root]}/base-#{title}-powerpc.cow/ --debug",
+                  :unless       => "test -e #{param_hash[:cow_root]}/base-#{title}-i386.cow",
+                  :environment  => ["DIST=#{title}", "ARCH=i386"],
+                  :logoutput    => "on_failure",
+                  :user         => "root",
+                  :timeout      => "0",
+                } )
+              end
+
+              it do should contain_cron("#{title}-i386").with({
+                  :command      => "cowbuilder --update --basepath=#{param_hash[:cow_root]}/base-#{title}-i386.cow > /dev/null 2>&1",
+                  :environment  => ["DIST=#{title}", "ARCH=i386", "PATH=/usr/sbin:/usr/bin:/bin:/sbin"],
+                  :hour         => "2",
+                  :minute       => "15",
+                  :user         => "root",
+                  :name         => "cowbuilder update for #{title}-i386",
+                })
+              end
+            end
+            if (arch_fact == /(amd64|arm(el|hf)?)/)
               it do should contain_exec("#{title}-#{arch}").with( {
                   :path         => "/usr/sbin:/usr/bin:/bin:/sbin",
                   :command      => "cowbuilder --create --basepath=#{param_hash[:cow_root]}/base-#{title}-#{arch}.cow/ --debug",
@@ -44,6 +66,28 @@ describe 'debbuilder::setup::cow_exec', :type => :define do
                   :minute       => "15",
                   :user         => "root",
                   :name         => "cowbuilder update for #{title}-#{arch}",
+                })
+              end
+            end
+            if (arch_fact =~ /(?i)(powerpc|ppc(64|32)?)/)
+              it do should contain_exec("#{title}-powerpc").with( {
+                  :path         => "/usr/sbin:/usr/bin:/bin:/sbin",
+                  :command      => "cowbuilder --create --basepath=#{param_hash[:cow_root]}/base-#{title}-powerpc.cow/ --debug",
+                  :unless       => "test -e #{param_hash[:cow_root]}/base-#{title}-powerpc.cow",
+                  :environment  => ["DIST=#{title}", "ARCH=powerpc"],
+                  :logoutput    => "on_failure",
+                  :user         => "root",
+                  :timeout      => "0",
+                } )
+              end
+
+              it do should contain_cron("#{title}-powerpc").with({
+                  :command      => "cowbuilder --update --basepath=#{param_hash[:cow_root]}/base-#{title}-powerpc.cow > /dev/null 2>&1",
+                  :environment  => ["DIST=#{title}", "ARCH=powerpc", "PATH=/usr/sbin:/usr/bin:/bin:/sbin"],
+                  :hour         => "2",
+                  :minute       => "15",
+                  :user         => "root",
+                  :name         => "cowbuilder update for #{title}-powerpc",
                 })
               end
             end


### PR DESCRIPTION
Currently the puppetlabs-debbuilder module only supports defining cows for i386
and amd64. To expand possibilities to building for powerand arm, we have to
make things a bit more flexible. This commit updates the cow_exec.pp manifest
to include execs/crons for i386 cows on i386 and amd64, and then for various
iterations of ppc and arm, those arches.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
