### PR TITLE
Allow upstream mirrors for pbuilderrc to be configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,13 +3,19 @@
 # for internal Puppet Labs builds, $use_cows sets up cows as builders and
 # brings in all the dependencies to set cows up. $cows and $cow_root customize
 # which cows are build during the setup phase and which basepath to use when
-# setting the cows up (if $use_cows is set to true).
+# setting the cows up (if $use_cows is set to true). $debian_mirror,
+# $debian_archive_mirror, and $ubuntu_mirror can be used to specify the mirrors
+# that will be used by pbuilder/cowbuilder during dependency resolution/OS
+# build.
 
 class debbuilder (
   $pe = false,
   $use_cows = false,
   $cows = undef,
   $cow_root = undef,
+  $debian_mirror = 'ftp.us.debian.org',
+  $debian_archive_mirror = 'archive.debian.org',
+  $ubuntu_mirror = 'us.archive.ubuntu.com',
 ) {
   include debbuilder::packages::essential
 

--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -21,9 +21,9 @@ DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $OLD_STABLE
 UBUNTU_SUITES=("maverick" "lucid" "karmic" "jaunty" "hardy" "natty" "oneiric" "precise" "quantal" "raring" "saucy")
 
 # Mirrors to use. Update these to your preferred mirror.
-DEBIAN_MIRROR="ftp.us.debian.org"
-DEBIAN_ARCHIVE_MIRROR="archive.debian.org"
-UBUNTU_MIRROR="us.archive.ubuntu.com"
+DEBIAN_MIRROR="<%= scope.lookupvar("debbuilder::debian_mirror") %>"
+DEBIAN_ARCHIVE_MIRROR="<%= scope.lookupvar("debbuilder::debian_archive_mirror") %>"
+UBUNTU_MIRROR="<%= scope.lookupvar("debbuilder::ubuntu_mirror") %>"
 
 # Optionally use the changelog of a package to determine the suite to use if
 # none set.


### PR DESCRIPTION
This commit adds configurability of the debian and ubuntu mirrors to use when
creating the pbuilderrc file. This way, if you have a custom internal debian
mirror, you can supply it in your debbuilder inclusion and use it to satisfy
deps for cows instead of the official debian/ubuntu mirrors.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
