### PR TITLE
Enable setting of OTHERMIRROR in pbuilderrc

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,18 @@
 # setting the cows up (if $use_cows is set to true). $debian_mirror,
 # $debian_archive_mirror, and $ubuntu_mirror can be used to specify the mirrors
 # that will be used by pbuilder/cowbuilder during dependency resolution/OS
-# build.
+# build. $other_mirror can be used to specify an extra repository in addition
+# to the OS mirror to use when satisfying dependencies. If not specified, this
+# defaults to apt.puppetlabs.com (which has been the historic behavior). If
+# specifies, it replaces apt.puppetlabs.com. Note that unlike the debian and
+# ubuntu OS mirrors, this mirror must be specified as a repo config, e.g.:
+#
+# "deb http://apt.puppetlabs.com ${DIST} main dependencies"
+#
+# where $DIST is wheezy, precise, etc.
+#
+# $install_pl_keyring enables the installation of the Puppet Labs gpg keyring.
+# This defaults to true, which has been the historic behavior.
 
 class debbuilder (
   $pe = false,
@@ -16,6 +27,8 @@ class debbuilder (
   $debian_mirror = 'ftp.us.debian.org',
   $debian_archive_mirror = 'archive.debian.org',
   $ubuntu_mirror = 'us.archive.ubuntu.com',
+  $other_mirror = undef,
+  $install_pl_keyring = true,
 ) {
   include debbuilder::packages::essential
 

--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -59,20 +59,28 @@ APTCACHEHARDLINK=no
 BUILDPLACE="/var/cache/pbuilder/build/"
 #BINDMOUNTS="/var/cache/archive"
 
+<% if @install_pl_keyring %>
+# Add apt.puppetlabs.com keyrings
+DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/puppetlabs-keyring.gpg")
+APTKEYRINGS="/usr/share/keyrings/puppetlabs-keyring.gpg"
+<% end %>
+
+<% if @other_mirror %>
+OTHERMIRROR="<%= @other_mirror %>"
+<% else %>
 if [ "${FOSS_DEVEL}" = 'true' ] ; then
   OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} main dependencies devel"
 else
   OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} main dependencies"
 fi
+<% end %>
 
-# Add apt.puppetlabs.com keyrings
-DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/puppetlabs-keyring.gpg")
-APTKEYRINGS="/usr/share/keyrings/puppetlabs-keyring.gpg"
 
-<% if scope.lookupvar("debbuilder::setup::cows::pe") then %>
+<% if scope.lookupvar("debbuilder::setup::cows::pe") %>
 if [ -n "${PE_VER}" ]; then
+  <% unless @other_mirror %>
   OTHERMIRROR="${OTHERMIRROR} | deb http://enterprise.delivery.puppetlabs.net/${PE_VER}/repos/debian ${DIST} ${DIST}/main"
-
+  <% end %>
   # Add pluto
   DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/pluto-build-keyring.gpg")
   APTKEYRINGS=("${APTKEYRINGS[@]}" "/usr/share/keyrings/pluto-build-keyring.gpg")


### PR DESCRIPTION
This commit updates the debbuilder module to allow the specification of a
different extra mirror than "apt.puppetlabs.com" which is set up by default.
This enables one to set up an internal extra apt repository that they want to
use to satisfy build dependencies, e.g. if one wanted to still use upstream
debian but also extra internal packages. Since this means we won't always be
using apt.puppetlabs.com as the OTHERMIRROR, we may not always want to install
the Puppet Labs keyring. As such, we make this configurable as well (because we
may still want the keyring, even if we don't want the repo).

Signed-off-by: Moses Mendoza moses@puppetlabs.com
