### PR TITLE
Enable configuration of components to use from repos

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,15 +18,21 @@
 #
 # $install_pl_keyring enables the installation of the Puppet Labs gpg keyring.
 # This defaults to true, which has been the historic behavior.
+# $debian_components and $ubuntu_components allow you to specify the exact repo
+# components to select when satisfying dependencies. By default on debian this
+# is 'main contrib non-free' and on ubuntu this is 'main restricted universe
+# multiverse.'
 
 class debbuilder (
   $pe = false,
   $use_cows = false,
   $cows = undef,
   $cow_root = undef,
-  $debian_mirror = 'ftp.us.debian.org',
-  $debian_archive_mirror = 'archive.debian.org',
-  $ubuntu_mirror = 'us.archive.ubuntu.com',
+  $debian_mirror = undef,
+  $debian_archive_mirror = undef,
+  $debian_components = undef,
+  $ubuntu_mirror = undef,
+  $ubuntu_components = undef,
   $other_mirror = undef,
   $install_pl_keyring = true,
 ) {

--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -21,9 +21,23 @@ DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $OLD_STABLE
 UBUNTU_SUITES=("maverick" "lucid" "karmic" "jaunty" "hardy" "natty" "oneiric" "precise" "quantal" "raring" "saucy")
 
 # Mirrors to use. Update these to your preferred mirror.
-DEBIAN_MIRROR="<%= scope.lookupvar("debbuilder::debian_mirror") %>"
-DEBIAN_ARCHIVE_MIRROR="<%= scope.lookupvar("debbuilder::debian_archive_mirror") %>"
-UBUNTU_MIRROR="<%= scope.lookupvar("debbuilder::ubuntu_mirror") %>"
+<% if @debian_mirror %>
+DEBIAN_MIRROR="<%= @debian_mirror %>"
+<% else %>
+DEBIAN_MIRROR="ftp.us.debian.org"
+<% end %>
+
+<% if @debian_archive_mirror %>
+DEBIAN_ARCHIVE_MIRROR="<%= @debian_archive_mirror %>"
+<% else %>
+DEBIAN_ARCHIVE_MIRROR="archive.debian.org"
+<% end %>
+
+<% if @ubuntu_mirror %>
+UBUNTU_MIRROR="<%= @ubuntu_mirror %>"
+<% else %>
+UBUNTU_MIRROR="us.archive.ubuntu.com"
+<% end %>
 
 # Optionally use the changelog of a package to determine the suite to use if
 # none set.
@@ -89,12 +103,20 @@ fi
 
 if $(echo ${DEBIAN_SUITES[@]} | grep -q $DIST); then
     # Debian configuration
+<% if @debian_mirror %>
+    MIRRORSITE="http://<%= @debian_mirror %>"
+<% else %>
     if [ $DIST = "lenny" ]; then
       MIRRORSITE="http://$DEBIAN_ARCHIVE_MIRROR/debian/"
     else
       MIRRORSITE="http://$DEBIAN_MIRROR/debian/"
     fi
+<% end %>
+<% if @debian_components %>
+    COMPONENTS="<%= @debian_components %>"
+<% else %>
     COMPONENTS="main contrib non-free"
+<% end %>
     DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/debian-archive-keyring.gpg")
     # This is for enabling backports for the Debian stable suite.
     if $(echo "$STABLE_CODENAME stable" | grep -q $DIST); then
@@ -103,8 +125,16 @@ if $(echo ${DEBIAN_SUITES[@]} | grep -q $DIST); then
     fi
 elif $(echo ${UBUNTU_SUITES[@]} | grep -q $DIST); then
     # Ubuntu configuration
+<% if @ubuntu_mirror %>
+    MIRRORSITE="http://<%= @ubuntu_mirror %>"
+<% else %>
     MIRRORSITE="http://$UBUNTU_MIRROR/ubuntu/"
+<% end %>
+<% if @ubuntu_components %>
+    COMPONENTS="<%= @ubuntu_components %>"
+<% else %>
     COMPONENTS="main restricted universe multiverse"
+<% end %>
     DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg")
     OTHERMIRROR="$OTHERMIRROR"
 else


### PR DESCRIPTION
This commit enables one to specify the exact components from a repository to
use for dependency resolution. Previously, we still just assumed all of the
components from the default upstream existed, even if you specified a custom
upstream. This commit also corrects the setting of the MIRRORSITE variable in
the pbuilderrc. Previously, even when setting the debian or ubuntu upstream
mirrors, the subpathing of the url was assumed to be that of the default
upstream. Now we assume when you pass these values in, you really mean it.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
