### PR TITLE
Add additional options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,27 @@
 # components to select when satisfying dependencies. By default on debian this
 # is 'main contrib non-free' and on ubuntu this is 'main restricted universe
 # multiverse.'
+#
+# $debootstrap_components allows you to specify the repository components to
+# use with debootstrap. By default, debootstrap always assumes a repo will have
+# 'main'. If you have a repo you are using for your debootstrap mirror, and it
+# doesn't have main, it isn't going to work. If this variable is used, the
+# resulting string will be inserted into the pbuilderrc as a DEBOOTSTRAPOPTS
+# element. This should be a comma-separated string of components.
+#
+# $debootstrap_keyring allows you to specify the exact keyring file to use when
+# debootstrapping a base system. This is important when you have your own
+# debian distribution repo signed with your key, not debian's. By default,
+# debootstrap will use the very last '--keyring' argument as its canonical
+# keyring, which in the pbbuilderrc is debian's or ubuntu's. by using this
+# option, you append an extra '--keyring' option to DEBOOTSTRAPOPTS with the
+# value. This should be the path to a keyring file on disk.
 
+# $debian_suites/ubuntu_suites allows you to specify the distributions that
+# are defined as "suites" in the pbuilderrc, which is useful if you
+# aren't building a commonly accepted debian distribution. This should be a
+# space-separated string of debian suites.
+#
 class debbuilder (
   $pe = false,
   $use_cows = false,
@@ -35,6 +55,10 @@ class debbuilder (
   $ubuntu_components = undef,
   $other_mirror = undef,
   $install_pl_keyring = true,
+  $debootstrap_components = undef,
+  $debootstrap_keyring = undef,
+  $debian_suites = undef,
+  $ubuntu_suites = undef,
 ) {
   include debbuilder::packages::essential
 

--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -15,10 +15,18 @@ OLD_STABLE_BACKPORTS_SUITE="$OLD_STABLE_CODENAME-backports"
 HOOKDIR=/usr/share/pbuilder/hooks
 
 # List of Debian suites.
+<% if @debian_suites %>
+DEBIAN_SUITES=(<%= @debian_suites %>)
+<% else %>
 DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME $OLD_STABLE_CODENAME "unstable" "testing" "stable")
+<% end %>
 
+<% if @ubuntu_suites %>
+UBUNTU_SUITES=(<%= @ubuntu_suites %>)
+<% else %>
 # List of Ubuntu suites. Update these when needed.
 UBUNTU_SUITES=("maverick" "lucid" "karmic" "jaunty" "hardy" "natty" "oneiric" "precise" "quantal" "raring" "saucy")
+<% end %>
 
 # Mirrors to use. Update these to your preferred mirror.
 <% if @debian_mirror %>
@@ -77,6 +85,11 @@ BUILDPLACE="/var/cache/pbuilder/build/"
 # Add apt.puppetlabs.com keyrings
 DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/puppetlabs-keyring.gpg")
 APTKEYRINGS="/usr/share/keyrings/puppetlabs-keyring.gpg"
+<% end %>
+
+<% if @debootstrap_components %>
+# Components to use while debootstrapping
+DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--components=<%= @debootstrap_components %>")
 <% end %>
 
 <% if @other_mirror %>
@@ -141,6 +154,10 @@ else
     echo "Unknown distribution: $DIST"
     exit 1
 fi
+
+<% if @debootstrap_keyring %>
+DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=<%= @debootstrap_keyring %>")
+<% end %>
 
 # Workaround for http://bugs.debian.org/531885
 umask 022


### PR DESCRIPTION
Expose some new attributes!

$debootstrap_components allows you to specify the repository components to
use with debootstrap. By default, debootstrap always assumes a repo will have
'main'. If you have a repo you are using for your debootstrap mirror, and it
doesn't have main, it isn't going to work. If this variable is used, the
resulting string will be inserted into the pbuilderrc as a DEBOOTSTRAPOPTS
element. This should be a comma-separated string of components.

$debootstrap_keyring allows you to specify the exact keyring file to use when
debootstrapping a base system. This is important when you have your own
debian distribution repo signed with your key, not debian's. By default,
debootstrap will use the very last '--keyring' argument as its canonical
keyring, which in the pbbuilderrc is debian's or ubuntu's. by using this
option, you append an extra '--keyring' option to DEBOOTSTRAPOPTS with the
value. This should be the path to a keyring file on disk.

$debian_suites/ubuntu_suites allows you to specify the distributions that
are defined as "suites" in the pbuilderrc, which is useful if you
aren't building a commonly accepted debian distribution. This should be a
space-separated string of debian suites.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
