### PR TITLE
(maint) Add lintian profile for internal Puppet Labs builds

### DIFF
--- a/files/lintian-main.profile
+++ b/files/lintian-main.profile
@@ -1,0 +1,12 @@
+# Haus says "This file is managed by puppet; don't edit it or we'll put it back"
+Profile: puppetlabs/main
+Extends: debian/main
+Enable-Tags-From-Check: binaries, changelog-file, changes-file, conffiles,
+ control-file, control-files, copyright-file, cruft, deb-format, debconf,
+ debhelper, debian-readme, debian-source-dir, description, duplicate-files,
+ fields, filename-length, files, huge-usr-share, infofiles, init.d, java,
+ lintian, manpages, md5sums, menu-format, menus, nmu, ocaml, patch-systems,
+ po-debconf, rules, scripts, shared-libs, source-copyright, standards-version,
+ symlinks, version-substvars, watch-file
+Disable-Tags: bad-distribution-in-changes-file,multiple-distributions-in-changes-file,dir-or-file-in-opt,
+ binary-or-shlib-defines-rpath

--- a/manifests/packages/extra.pp
+++ b/manifests/packages/extra.pp
@@ -13,6 +13,7 @@ class debbuilder::packages::extra (
     'cowdancer',
     'debian-archive-keyring',
     'debian-keyring',
+    'lintian',
     'pbuilder',
     'git-buildpackage',
     'libparse-debianchangelog-perl',
@@ -21,6 +22,23 @@ class debbuilder::packages::extra (
   package { $extra_packages: ensure => present, }
 
   if ($pe) {
+    file { 'puppetlabs lintian profile directory':
+      ensure  => directory,
+      path    => '/usr/share/lintian/profiles/puppetlabs',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      require => Package['lintian'],
+    }
+
+    file { 'main.profile':
+      ensure  => present,
+      source  => 'puppet:///modules/debbuilder/lintian-main.profile',
+      path    => '/usr/share/lintian/profiles/puppetlabs/main.profile',
+      mode    => '0644',
+      require => File['puppetlabs lintian profile directory'],
+    }
+
     package { 'cowsay':
       ensure => present,
     }


### PR DESCRIPTION
This adds the `lintian` package to the `$extra_packages` variable, as a compliment to [Puppet Modules PR 1212](https://github.com/puppetlabs/puppetlabs-modules/pull/1212).
