### PR TITLE
(RE-825) Disable cowbuilder updates

### DIFF
--- a/manifests/setup/cow_exec.pp
+++ b/manifests/setup/cow_exec.pp
@@ -17,12 +17,8 @@ define debbuilder::setup::cow_exec ( $cow_root = '/var/cache/pbuilder' ) {
     }
 
     cron { "${name}-i386":
-      command       => "cowbuilder --update --basepath=${cow_root}/base-${name}-i386.cow > /dev/null 2>&1",
-      environment   => ["DIST=${name}", 'ARCH=i386', 'PATH=/usr/sbin:/usr/bin:/bin:/sbin'],
-      hour          => '2',
-      minute        => '15',
-      name          => "cowbuilder update for ${name}-i386",
-      user          => root,
+      name   => "cowbuilder update for ${name}-i386",
+      ensure => 'absent',
     }
   }
 
@@ -38,12 +34,8 @@ define debbuilder::setup::cow_exec ( $cow_root = '/var/cache/pbuilder' ) {
     }
 
     cron { "${name}-${::architecture}":
-      command       => "cowbuilder --update --basepath=${cow_root}/base-${name}-${::architecture}.cow > /dev/null 2>&1",
-      environment   => ["DIST=${name}", "ARCH=${::architecture}", 'PATH=/usr/sbin:/usr/bin:/bin:/sbin'],
-      hour          => '2',
-      minute        => '15',
-      name          => "cowbuilder update for ${name}-${::architecture}",
-      user          => root,
+      name   => "cowbuilder update for ${name}-${::architecture}",
+      ensure => 'absent',
     }
   }
 
@@ -58,12 +50,8 @@ define debbuilder::setup::cow_exec ( $cow_root = '/var/cache/pbuilder' ) {
     }
 
     cron { "${name}-powerpc":
-      command       => "cowbuilder --update --basepath=${cow_root}/base-${name}-powerpc.cow > /dev/null 2>&1",
-      environment   => ["DIST=${name}", "ARCH=powerpc", 'PATH=/usr/sbin:/usr/bin:/bin:/sbin'],
-      hour          => '2',
-      minute        => '15',
-      name          => "cowbuilder update for ${name}-powerpc",
-      user          => root,
+      name   => "cowbuilder update for ${name}-powerpc",
+      ensure => 'absent',
     }
   }
 }

--- a/spec/defines/setup_cow_exec_spec.rb
+++ b/spec/defines/setup_cow_exec_spec.rb
@@ -38,12 +38,8 @@ describe 'debbuilder::setup::cow_exec', :type => :define do
               end
 
               it do should contain_cron("#{title}-i386").with({
-                  :command      => "cowbuilder --update --basepath=#{param_hash[:cow_root]}/base-#{title}-i386.cow > /dev/null 2>&1",
-                  :environment  => ["DIST=#{title}", "ARCH=i386", "PATH=/usr/sbin:/usr/bin:/bin:/sbin"],
-                  :hour         => "2",
-                  :minute       => "15",
-                  :user         => "root",
-                  :name         => "cowbuilder update for #{title}-i386",
+                  :name   => "cowbuilder update for #{title}-i386",
+                  :ensure => 'absent',
                 })
               end
             end
@@ -60,12 +56,8 @@ describe 'debbuilder::setup::cow_exec', :type => :define do
               end
 
               it do should contain_cron("#{title}-#{arch}").with({
-                  :command      => "cowbuilder --update --basepath=#{param_hash[:cow_root]}/base-#{title}-#{arch}.cow > /dev/null 2>&1",
-                  :environment  => ["DIST=#{title}", "ARCH=#{arch}", "PATH=/usr/sbin:/usr/bin:/bin:/sbin"],
-                  :hour         => "2",
-                  :minute       => "15",
-                  :user         => "root",
-                  :name         => "cowbuilder update for #{title}-#{arch}",
+                  :name   => "cowbuilder update for #{title}-#{arch}",
+                  :ensure => 'absent',
                 })
               end
             end
@@ -82,12 +74,8 @@ describe 'debbuilder::setup::cow_exec', :type => :define do
               end
 
               it do should contain_cron("#{title}-powerpc").with({
-                  :command      => "cowbuilder --update --basepath=#{param_hash[:cow_root]}/base-#{title}-powerpc.cow > /dev/null 2>&1",
-                  :environment  => ["DIST=#{title}", "ARCH=powerpc", "PATH=/usr/sbin:/usr/bin:/bin:/sbin"],
-                  :hour         => "2",
-                  :minute       => "15",
-                  :user         => "root",
-                  :name         => "cowbuilder update for #{title}-powerpc",
+                  :name   => "cowbuilder update for #{title}-powerpc",
+                  :ensure => 'absent',
                 })
               end
             end


### PR DESCRIPTION
All of these jobs were set up to run at the same time; totally irresponsible.
And apparently we don't even need them anymore, so we might as well remove them.
