### PR TITLE
(maint) Remove raring from default cows

### DIFF
--- a/manifests/setup/cows.pp
+++ b/manifests/setup/cows.pp
@@ -17,7 +17,6 @@ class debbuilder::setup::cows (
     'lucid',
     'precise',
     'quantal',
-    'raring',
     'saucy',
     'sid',
     'squeeze',


### PR DESCRIPTION
It is EOL now, so let's not default to making the cow.
