### PR TITLE
(RE-2129) Only use one OTHERMIRROR in pbuilderrc

### DIFF
--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -106,7 +106,7 @@ fi
 <% if scope.lookupvar("debbuilder::setup::cows::pe") %>
 if [ -n "${PE_VER}" ]; then
   <% unless @other_mirror %>
-  OTHERMIRROR="${OTHERMIRROR} | deb http://enterprise.delivery.puppetlabs.net/${PE_VER}/repos/debian ${DIST} ${DIST}/main"
+  OTHERMIRROR="deb http://enterprise.delivery.puppetlabs.net/${PE_VER}/repos/debian ${DIST} ${DIST}/main"
   <% end %>
   # Add pluto
   DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/pluto-build-keyring.gpg")


### PR DESCRIPTION
Previously, when setting PE_VER to enable a PE cow, we would continue to
include the apt.puppetlabs.com repo, even though we would use none of
those packages. This commit updates the pbuilderrc to set OTHERMIRROR to
be one or the other, but never both. This has the added bonus of
negating an edge case segfault we've seen on precise-amd64 cows that
have both repos enabled.
