### PR TITLE
(RE-2157) Allow override of $OTHERMIRROR by tooling

### DIFF
--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -92,27 +92,35 @@ APTKEYRINGS="/usr/share/keyrings/puppetlabs-keyring.gpg"
 DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--components=<%= @debootstrap_components %>")
 <% end %>
 
-<% if @other_mirror %>
-OTHERMIRROR="<%= @other_mirror %>"
-<% else %>
-if [ "${FOSS_DEVEL}" = 'true' ] ; then
-  OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} main dependencies devel"
-else
-  OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} main dependencies"
-fi
-<% end %>
+if [ -n "${BUILDMIRROR}" ]; then
+  OTHERMIRROR=$BUILDMIRROR
 
-
-<% if scope.lookupvar("debbuilder::setup::cows::pe") %>
-if [ -n "${PE_VER}" ]; then
-  <% unless @other_mirror %>
-  OTHERMIRROR="deb http://enterprise.delivery.puppetlabs.net/${PE_VER}/repos/debian ${DIST} ${DIST}/main"
-  <% end %>
-  # Add pluto
+  # Add internal signing key
   DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/pluto-build-keyring.gpg")
   APTKEYRINGS=("${APTKEYRINGS[@]}" "/usr/share/keyrings/pluto-build-keyring.gpg")
+else
+  <% if @other_mirror %>
+  OTHERMIRROR="<%= @other_mirror %>"
+  <% else %>
+  if [ "${FOSS_DEVEL}" = 'true' ] ; then
+    OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} main dependencies devel"
+  else
+    OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} main dependencies"
+  fi
+  <% end %>
+
+
+  <% if scope.lookupvar("debbuilder::setup::cows::pe") %>
+  if [ -n "${PE_VER}" ]; then
+    <% unless @other_mirror %>
+    OTHERMIRROR="deb http://enterprise.delivery.puppetlabs.net/${PE_VER}/repos/debian ${DIST} ${DIST}/main"
+    <% end %>
+    # Add internal signing key
+    DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/pluto-build-keyring.gpg")
+    APTKEYRINGS=("${APTKEYRINGS[@]}" "/usr/share/keyrings/pluto-build-keyring.gpg")
+  fi
+  <% end %>
 fi
-<% end %>
 
 if $(echo ${DEBIAN_SUITES[@]} | grep -q $DIST); then
     # Debian configuration


### PR DESCRIPTION
As our build tools become more diverse the complexity of the pbuilderrc
grows. In order to avoid that somewhat while allowing added flexibility
in what repos to build against, this commit adds an environment variable
which is honored by the pbuilderrc. If the packaging tooling sets
$BUILDMIRROR, that will be used as OTHERMIRROR instead of apt.pl.com or
enterprise.dl.pl.net. BUILDMIRROR can include more than one repo as long
as they are pipe separated.
