### PR TITLE
(maint) Re-add gpg to extra packages

### DIFF
--- a/manifests/packages/extra.pp
+++ b/manifests/packages/extra.pp
@@ -17,6 +17,7 @@ class debbuilder::packages::extra (
     'pbuilder',
     'git-buildpackage',
     'libparse-debianchangelog-perl',
+    'gnupg-agent',
   ]
 
   package { $extra_packages: ensure => present, }


### PR DESCRIPTION
Once upon a time there was a conflict with the packages that the gpg module brought in. This conflict appears to have been resolved, based on reading of git logs, so this PR brings back the gpg module and the gnupg-agent package to the extra.pp.
