### PR TITLE
Update which repos are enabled on which platforms

### DIFF
--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -53,9 +53,6 @@ UBUNTU_MIRROR="us.archive.ubuntu.com"
 # List of old debian/ubuntu suites that require the traditional apt mirror
 OLD_SUITES=("squeeze" $STABLE_CODENAME $OLD_STABLE_CODENAME "testing" "stable" "lucid" "precise" "trusty" "utopic")
 
-# List of debian/ubuntu suites that do not have the PC1 repo available
-NO_PC1=("lucid" "stable" "testing")
-
 # Optionally use the changelog of a package to determine the suite to use if
 # none set.
 if [ -z "${DIST}" ] && [ -r "debian/changelog" ]; then
@@ -107,21 +104,17 @@ else
   <% if @other_mirror %>
   OTHERMIRROR="<%= @other_mirror %>"
   <% else %>
-  components="PC1"
+  # Only enable apt.puppetlabs.com repos if we have the main/dependencies repos available
+  # this will only be the case on older platforms added in the pre-puppet4 era
   if $(echo ${OLD_SUITES[@]} | grep -q $DIST) ; then
-    old_components="main dependencies"
-    if $(echo ${NO_PC1[@]} | grep -q $DIST) ; then
-      components="${old_components}"
-    else
-      components="${components} ${old_components}"
+    components="${components} main dependencies"
+    if [ "${FOSS_DEVEL}" = 'true' ] ; then
+      components="${components} devel"
     fi
-  fi
-  if [ "${FOSS_DEVEL}" = 'true' ] ; then
-    components="${components} devel"
-  fi
-  no_pl_apt_repo=($UNSTABLE_CODENAME "unstable" )
-  if !(echo ${no_pl_apt_repo[@]} | grep -q $DIST) ; then
-    OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} ${components}"
+    no_pl_apt_repo=($UNSTABLE_CODENAME "unstable" )
+    if !(echo ${no_pl_apt_repo[@]} | grep -q $DIST) ; then
+      OTHERMIRROR="deb http://apt.puppetlabs.com ${DIST} ${components}"
+    fi
   fi
   <% end %>
 

--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -51,7 +51,7 @@ UBUNTU_MIRROR="us.archive.ubuntu.com"
 <% end %>
 
 # List of old debian/ubuntu suites that require the traditional apt mirror
-OLD_SUITES=("squeeze" $STABLE_CODENAME $OLD_STABLE_CODENAME "testing" "stable" "lucid" "precise" "trusty" "utopic")
+OLD_SUITES=("lucid" "precise" "squeeze" "stable" "testing" "trusty" "wheezy")
 
 # Optionally use the changelog of a package to determine the suite to use if
 # none set.


### PR DESCRIPTION
We want to not enable PC1 repos though this template, and only enable oldstyle apt.pl.com repos on platforms where they are available.