### PR TITLE
Switch to using ensure_packages().

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -10,3 +10,4 @@ project_page 'https://github.com/puppetlabs/puppetlabs-debbuilder.git'
 ## Add dependencies, if any:
 dependency 'ploperations/git', '>= 0.0.1'
 dependency 'ploperations/gpg', '>= 0.0.1'
+dependancy 'puppetlabs/stdlib', '>= 0.0.1'

--- a/manifests/packages/essential.pp
+++ b/manifests/packages/essential.pp
@@ -16,7 +16,9 @@ class debbuilder::packages::essential {
     'rake',
   ]
 
-  package { $builder_packages: ensure => present, }
+  ensure_packages( $builder_packages, {
+    ensure => present,
+  })
 
   include git
 }

--- a/manifests/packages/extra.pp
+++ b/manifests/packages/extra.pp
@@ -19,7 +19,9 @@ class debbuilder::packages::extra (
     'libparse-debianchangelog-perl',
   ]
 
-  package { $extra_packages: ensure => present, }
+  ensure_packages( $extra_packages, {
+    ensure => present,
+  })
 
   if ($pe) {
     file { 'puppetlabs lintian profile directory':
@@ -39,9 +41,9 @@ class debbuilder::packages::extra (
       require => File['puppetlabs lintian profile directory'],
     }
 
-    package { 'cowsay':
+    ensure_packages( 'cowsay', {
       ensure => present,
-    }
+    })
   }
 
   include "gpg"


### PR DESCRIPTION
Changed package includes in essentials.pp and extra.pp to use ensure_packages() to help avoid dependency conflicts. 
We're trying to add the ability to build debian packages to our CI Slaves and we'd like to puppetise it using this module. Unfortunately we already use a lot of the packages included in this package elsewhere and there's a lot of dependency conflicts. This change would remove most of these conflicts and shouldn't impact the functionality of the module.