### PR TITLE
Optional bash-completion package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class debbuilder (
   $ubuntu_components = undef,
   $other_mirror = undef,
   $install_pl_keyring = true,
+  $manage_bashcompletion_package = true,
   $debootstrap_components = undef,
   $debootstrap_keyring = undef,
   $debian_suites = undef,
@@ -67,7 +68,7 @@ class debbuilder (
 
   if ($use_cows) {
     class { 'debbuilder::packages::extra':
-      pe => $pe,
+      pe     => $pe,
       ensure => $ensure,
     }
 

--- a/manifests/packages/extra.pp
+++ b/manifests/packages/extra.pp
@@ -9,7 +9,6 @@ class debbuilder::packages::extra (
 ){
 
   $extra_packages = [
-    'bash-completion',
     'cowbuilder',
     'cowdancer',
     'debian-archive-keyring',
@@ -20,6 +19,11 @@ class debbuilder::packages::extra (
     'libparse-debianchangelog-perl',
   ]
 
+  if $debbuilder::manage_bashcompletion_package {
+    package { 'bash-completion':
+      ensure => $ensure,
+    }
+  }
   ensure_packages( $extra_packages, {
     ensure => $ensure,
   })


### PR DESCRIPTION
- Others might want to manage the bash-completion package with their
  bash Puppet module without being forced to use the unpredictable
  ensure_packages function.

- Adds a parameter to make this package optional.