### PR TITLE
(maint) Actually pass in the mirror vars

### DIFF
--- a/manifests/setup/cows.pp
+++ b/manifests/setup/cows.pp
@@ -28,7 +28,10 @@ class debbuilder::setup::cows (
     'CumulusLinux-2.2',
   ],
   $cow_root = '/var/cache/pbuilder',
-  $pe = false
+  $pe = false,
+  $debian_mirror = undef,
+  $debian_archive_mirror = undef,
+  $ubuntu_mirror = undef,
 ) {
   case $pe {
       false:    { $cow_depends = [


### PR DESCRIPTION
This commit is a follow up to a previous commit. We need the ability to
customize the mirrors that we are using in our cows. We have the mirror
variables, but they never actually make it to the manifest that parses
the template that defines the repos the cows hit. This commit adds those
variables to the method that sets up the cows